### PR TITLE
Fix top-line Paeth unfiltering (equivalent to sub, rather than no-op)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ pub fn unfilter_lines<const BYTES_PER_PIXEL: usize>(lines: ChunksExactMut<'_, u8
       1 => unsafe { sub(line) },
       2 => (),
       3 => unsafe { average_top(line) },
-      4 => (),
+      4 => unsafe { sub(line) },
       _ => (),
     }
     *filter = 0;


### PR DESCRIPTION
On the top line, Paeth unfiltering is equivalent to the sub operation; this is a one-line patch to fix it.

(References: [the spec](https://www.w3.org/TR/png/#9Filter-type-4-Paeth), [Wikipedia's summary](https://en.wikipedia.org/wiki/PNG#Filtering).  Since `b` and `c` are 0, the predicted value will always be `a` -- the value predicted by `sub`.)